### PR TITLE
Remove page-driven events

### DIFF
--- a/js/segment.js
+++ b/js/segment.js
@@ -15,7 +15,4 @@ analytics.ready( function() {
     clientId: ga.getAll()[0].get('clientId'),
     querystrings: urlParams
   });
-  analytics.track('Visited /docker');
-  var home = document.querySelectorAll('[href="https://runnable.com"]')
-  analytics.trackLink(home, 'Visited Runnable from /docker');
 });


### PR DESCRIPTION
This is an anti-pattern, and isn't needed with the analytics tools we're using.